### PR TITLE
Add PR validation workflow with status comments

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,6 @@ name: CI
 on:
   push:
     branches: [master]
-  pull_request:
-    branches: [master]
 
 jobs:
   build:

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -1,0 +1,98 @@
+name: PR Validation
+
+on:
+  pull_request:
+    branches: [master]
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  validate:
+    name: Validate Pull Request
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Type check
+        run: npm run type-check
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Format check
+        run: npm run format:check
+
+      - name: Test
+        run: npm run test
+
+      - name: Build
+        run: npm run build
+
+      - name: Comment on PR
+        if: always()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const status = '${{ job.status }}' === 'success' ? '✅ PASSED' : '❌ FAILED';
+            const emoji = '${{ job.status }}' === 'success' ? '🎉' : '💥';
+
+            const body = `${emoji} **PR Validation ${status}**
+
+            **Commit:** \`${{ github.sha }}\`
+            **Branch:** \`${{ github.head_ref }}\`
+
+            **Checks:**
+            - ${'${{ job.status }}' === 'success' ? '✅' : '❌'} Dependencies installed
+            - ${'${{ job.status }}' === 'success' ? '✅' : '❌'} Type check passed
+            - ${'${{ job.status }}' === 'success' ? '✅' : '❌'} Linting passed
+            - ${'${{ job.status }}' === 'success' ? '✅' : '❌'} Format check passed
+            - ${'${{ job.status }}' === 'success' ? '✅' : '❌'} Tests passed
+            - ${'${{ job.status }}' === 'success' ? '✅' : '❌'} Build successful
+
+            ${status === '✅ PASSED' ? '**Ready to merge!** ✨' : '**Please fix issues before merging.**'}
+
+            ---
+            🔗 [View workflow run](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})
+            ⏰ Generated at: \`${new Date().toISOString()}\``;
+
+            const comments = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+
+            const botComment = comments.data.find(comment =>
+              comment.user.login === 'github-actions[bot]' &&
+              comment.body.includes('PR Validation')
+            );
+
+            if (botComment) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: botComment.id,
+                body: body
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body: body
+              });
+            }


### PR DESCRIPTION
## Summary
- Adds `pr-validation.yml` workflow that auto-comments on PRs with validation checklist
- Updates `ci.yml` to only trigger on push to master (avoids duplicate runs on PRs)
- Matches PR comment style from vreshch.com and diffractwd.com

## What changed
- **ci.yml**: Removed `pull_request` trigger (now push-only)
- **pr-validation.yml**: New workflow for PR validation with bot comment

## Test plan
- [ ] PR validation workflow runs on this PR
- [ ] Bot comment appears with checklist (type-check, lint, format, test, build)
- [ ] CI still runs on push to master