### PR TITLE
chore: add tsconfig.tsbuildinfo to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ npm-debug.log
 .DS_Store
 lerna-debug.log
 .npmrc
+
+# typescript
+*.tsbuildinfo


### PR DESCRIPTION
## Summary
- Add `*.tsbuildinfo` pattern to `.gitignore` to prevent TypeScript incremental build cache files from being committed to the repository.

## Test plan
- [ ] Verify `.gitignore` includes the new `*.tsbuildinfo` entry
- [ ] Confirm any existing `*.tsbuildinfo` files are no longer tracked by git
- [ ] Run `npm run build` and verify `*.tsbuildinfo` files are ignored