### PR TITLE
chore: finalize standards alignment

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,45 +1,81 @@
-# Molpad
+# MolPad
 
 [![GitHub Build Status](https://github.com/chemistry/molpad/workflows/CI/badge.svg)](https://github.com/chemistry/molpad/actions?query=workflow%3ACI)
-[![License: MIT](https://img.shields.io/badge/License-MIT-gren.svg)](https://opensource.org/licenses/MIT)
+[![npm version](https://img.shields.io/npm/v/@chemistry/molpad)](https://www.npmjs.com/package/@chemistry/molpad)
+[![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](https://opensource.org/licenses/MIT)
 
-Simple Molecule Editor
+React component for drawing and editing molecular structures.
+
 ![MolPad](https://github.com/chemistry/molpad/blob/master/molpad.png?raw=true)
 
-## How to use
+## Installation
 
-```javascript
-import { MolPad } from '../src/molpad';
-import * as React from 'react';
-import * as ReactDOM from 'react-dom';
-
-ReactDOM.render(
-    (<MolPad />),
-    document.getElementById('app') as HTMLElement
-);
+```bash
+npm install @chemistry/molpad
 ```
 
-## Technical description (all libraries):
+## Usage
 
-- Typescript 3.7
-- Auto tests with JEST
-- Height code coverage
+```tsx
+import { useRef } from 'react';
+import { MolPad, MolPadHandle } from '@chemistry/molpad';
 
-## Commands:
+function App() {
+  const molpadRef = useRef<MolPadHandle>(null);
 
-- Start demo project: `npm start`
-- Run linter verification: `npm run lint`
-- Run linter verification & fix: `npm run lintfix`
-- Build project: `npm run build`
+  const loadMolecule = () => {
+    molpadRef.current?.loadMolecule(moleculeData);
+  };
+
+  const exportMolecule = () => {
+    const jmol = molpadRef.current?.getJmol();
+    console.log(jmol);
+  };
+
+  return <MolPad ref={molpadRef} />;
+}
+```
+
+## Tech Stack
+
+- React 18/19, TypeScript 5.9, ES2024 target, ESM
+- Zustand 5 for state management (with devtools)
+- Vitest for testing, 98%+ coverage (270 tests)
+- ESLint 10 (flat config) + Prettier
+- Native `tsc` build (no bundler)
+- Node.js 22+
+
+## Commands
+
+| Command                | Description                                                   |
+| ---------------------- | ------------------------------------------------------------- |
+| `npm run build`        | Build the library                                             |
+| `npm run test`         | Run unit tests                                                |
+| `npm run lint`         | Run ESLint                                                    |
+| `npm run format:check` | Check Prettier formatting                                     |
+| `npm run type-check`   | Run TypeScript type checking                                  |
+| `npm run verify`       | Full verification (type-check + lint + format + test + build) |
+
+## Showcase App
+
+A Vite-based demo is available in `showcase/`:
+
+```bash
+cd showcase
+npm install
+npm run dev
+```
 
 ## Release
 
 ```bash
-git tag v2.3.0
+git tag v3.1.0
 git push --tags
 ```
 
+The `release.yml` GitHub Action will publish to npm and create a GitHub Release automatically.
+
 ## License
 
-This project is licensed under the MIT license, Copyright (c) 2020 Volodymyr Vreshch.
-For more information see [LICENSE.md](https://github.com/chemistry/crystalview/blob/master/LICENSE).
+This project is licensed under the MIT license, Copyright (c) 2025 Volodymyr Vreshch.
+For more information see [LICENSE](https://github.com/chemistry/molpad/blob/master/LICENSE).

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "molecule sketcher"
   ],
   "engines": {
-    "node": ">=20.0.0",
+    "node": ">=22.0.0",
     "npm": ">=10.0.0"
   },
   "repository": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "ES2024",
     "module": "ESNext",
     "moduleResolution": "bundler",
     "strict": true,
@@ -12,7 +12,7 @@
     "forceConsistentCasingInFileNames": true,
     "isolatedModules": true,
     "jsx": "react-jsx",
-    "lib": ["ES2020", "DOM"],
+    "lib": ["ES2024", "DOM"],
     "outDir": "./dist",
     "rootDir": "./src"
   },


### PR DESCRIPTION
## Summary

- Update TypeScript target from ES2020 to ES2024 and lib to match
- Update Node.js engines constraint from >=20.0.0 to >=22.0.0
- Rewrite README.md with current tech stack, commands, and usage example (replaces outdated Jest/TS 3.7/ReactDOM.render references)

## Test plan

- [x] `npm run verify` passes (type-check + lint + format + test + build)
- [x] All 270 tests passing
- [x] CI pipeline passes on PR