### PR TITLE
chore: bump LICENSE year to 2026

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2020 Chemistry
+Copyright (c) 2026 Chemistry
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Stale 2020. Bumps Copyright (c) 2020 → 2026 Chemistry. No code change.